### PR TITLE
feat/gf: workaround provisioning grafana DS

### DIFF
--- a/data-keeper/env.json
+++ b/data-keeper/env.json
@@ -1,0 +1,13 @@
+{
+    "PROMETHEUS_URL": "http://prometheus:9090",
+    "GF_URL": "http://localhost:3000",
+    "GF_SECURITY_ADMIN_USER": "admin",
+    "GF_SECURITY_ADMIN_PASSWORD": "admin",
+    "GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION": false,
+    "GF_ALERTING_ENABLED": false,
+    "INFLUXDB_URL": "http://influxdb:8086",
+    "INFLUXDB_ADMIN_ENABLED": true,
+    "INFLUXDB_DB": "prometheus",
+    "INFLUXDB_ADMIN_USER": "admin",
+    "INFLUXDB_ADMIN_PASSWORD": "superp@$"
+}

--- a/data-keeper/grafana/base-ds.json
+++ b/data-keeper/grafana/base-ds.json
@@ -1,0 +1,18 @@
+{
+    "orgId": 1,
+    "name": "CHANGE_ME",
+    "type": "CHANGE_ME",
+    "access": "proxy",
+    "url": "CHANGE_ME",
+    "password": "",
+    "user": "",
+    "database": "",
+    "basicAuth": false,
+    "basicAuthUser": "",
+    "basicAuthPassword": "",
+    "withCredentials": false,
+    "isDefault": false,
+    "jsonData": {},
+    "secureJsonFields": {},
+    "readOnly": false
+}

--- a/data-keeper/grafana/grafana-dash-fixes.py
+++ b/data-keeper/grafana/grafana-dash-fixes.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+grafana-dash-fixes will look to "desired" state
+of the dashboard to be successfull loaded on a local
+Grafana environment.
+Example of changes:
+- payload returned by API should be contain the value of .dashboard
+- refresh variables should be reloaded when time range has changed
+
+Usage: cat dashboard.json | python3 grafana-dash-fixes.py
+
+{License_info}
+"""
+
+import sys
+import os
+import json
+import logging
+
+
+def extract_dashboard_payload(data):
+    """ Extract .dashboard from raw Grafana API response """
+    try:
+        return data['dashboard']
+    except KeyError as e:
+        return {
+            "errorMessage": e,
+            "error": "Error extracting .dashboard from current payload"
+        }
+    except Exception as e:
+        raise e
+
+
+def fix_refresh_behavior(data):
+    """
+    Fix Dashboard variables refresh method from "On Dashboard Load" to
+    "On Time Range Change" to automatic discover new variables
+    when exploring old data.
+    PR opened to fix it: https://github.com/openshift/cluster-monitoring-operator/pull/1097
+    """
+    def_refresh = 2
+    for t in data['templating']['list']:
+        if t['query'].startswith('label_values'):
+            logging.debug(f"Updating refresh behavior for variable {t['name']} from value {t['refresh']} to {def_refresh}")
+            t['refresh'] = 2
+    return data
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO,
+                        format='%(asctime)s: %(message)s',
+                        datefmt='%Y-%m-%d %H:%M:%S')
+
+    try:
+        data = sys.stdin.readlines()
+        payload = extract_dashboard_payload(json.loads(data[0]))
+        payload = fix_refresh_behavior(payload)
+        print(json.dumps(payload))
+    except Exception as e:
+        logging.eror(e)
+        sys.exit(1)

--- a/data-keeper/grafana/grafana-ds-init.py
+++ b/data-keeper/grafana/grafana-ds-init.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Deprecated script to use Grafana provisioning
+Script to setup custom Datasources on Grafana.
+Grafana provisioning was not working properly
+when using DS name 'default'.
+Issue tracked on https://github.com/grafana/grafana/issues/32460
+{License_info}
+"""
+
+import os
+import json
+import logging
+import copy
+import requests
+from requests.auth import HTTPBasicAuth
+
+
+with open('./env.json', 'r') as f:
+    defaults_env = json.loads(f.read())
+
+
+with open('./base-ds.json', 'r') as f:
+    defaults_ds = json.loads(f.read())
+
+
+def build_ds_prometheus(name='default',
+                        url=os.getenv('PROMETHEUS_URL', defaults_env['PROMETHEUS_URL']),
+                        isDefault=False
+                        ):
+    ds = copy.deepcopy(defaults_ds)
+    ds['name'] = name
+    ds['url'] = url
+    ds['type'] = "prometheus"
+    ds['isDefault'] = isDefault
+    return ds
+
+
+def build_ds_influxdb(name='influxdb-prom',
+                      url=os.getenv('INFLUXDB_URL', defaults_env['INFLUXDB_URL'])):
+    ds = copy.deepcopy(defaults_ds)
+    ds['name'] = name
+    ds['url'] = url
+    ds['type'] = "influxdb"
+    ds['database'] = os.getenv('INFLUXDB_DB', defaults_env['INFLUXDB_DB'])
+    ds['isDefault'] = False
+    ds['basicAuth'] = True
+    ds['basicAuthUser'] = os.getenv('INFLUXDB_ADMIN_USER', defaults_env['INFLUXDB_ADMIN_USER'])
+    ds['basicAuthPassword'] = os.getenv('INFLUXDB_ADMIN_PASSWORD', defaults_env['INFLUXDB_ADMIN_PASSWORD'])
+    return ds
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO,
+                        format='%(asctime)s: %(message)s',
+                        datefmt='%Y-%m-%d %H:%M:%S')
+
+    gf_url = os.getenv('GF_URL', defaults_env['GF_URL'])
+    gf_usr = os.getenv('GF_SECURITY_ADMIN_USER', defaults_env['GF_SECURITY_ADMIN_USER'])
+    gf_pass = os.getenv('GF_SECURITY_ADMIN_USER', defaults_env['GF_SECURITY_ADMIN_USER'])
+    
+    gf_url_ds = (f"{gf_url}/api/datasources")
+    gf_auth = HTTPBasicAuth(gf_usr, gf_pass)
+    logging.info(f"Using Grafana login user: {gf_usr}")
+    logging.info(f"GF DS endpoint: {gf_url_ds}")
+
+    # Create Prometheus DS
+    resp = None
+    try:
+        logging.info("Creating Prometheus Datasource 02")
+        ds_prom = build_ds_prometheus(name="must-gather-prometheus", isDefault=True)
+        logging.info(f"-> Payload: {ds_prom}")
+        resp = requests.post(gf_url_ds, data=ds_prom, auth=gf_auth)
+        logging.info(f"-> DS Prometheus creation status code: {resp}")
+        if resp.status_code/100 != 2:
+            logging.info(resp.text)
+    except Exception as e:
+        logging.info(f"-> DS Prometheus creation error code: {resp}")
+        logging.error(e)
+        pass
+
+    # Create InfluxDB DS
+    resp = None
+    try:
+        logging.info("Creating InfluxDB Datasource")
+        ds_influxdb = build_ds_influxdb(name="must-gather-influxdb")
+        logging.info(f"-> Payload: {ds_influxdb}")
+        resp = requests.post(gf_url_ds, data=ds_influxdb, auth=gf_auth)
+        logging.info(f"-> DS creation status code: {resp}")
+        if resp.status_code/100 != 2:
+            logging.info(resp.text)
+    except Exception as e:
+        logging.info(f"-> DS creation error code: {resp}")
+        logging.error(e)
+        pass

--- a/grafana/provisioning/datasources/datasources.yaml
+++ b/grafana/provisioning/datasources/datasources.yaml
@@ -1,5 +1,8 @@
 apiVersion: 1
 
+# Desired state is prometheus datasource named as 'default'
+# Bug tracked by issue https://github.com/grafana/grafana/issues/32460
+
 deleteDatasources:
   - name: must-gather-prometheus
     orgId: 1


### PR DESCRIPTION
Workaround for DS provision, both has the same results as the bug is in Grafana UI[1].

ATM don't need to use this script as Grafana provisoining feature does the same.

[1] Grafana PR References is on the script's header.
[2] force variables refresh: PR https://github.com/openshift/cluster-monitoring-operator/pull/1097